### PR TITLE
Improve asset app with dashboard and categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# app
+# App Gestione Patrimonio
+
+Questa semplice applicazione web permette di creare e gestire conti con un nome, dei tag associati e un registro di transazioni. I dati sono salvati nel `localStorage` del browser, quindi non è richiesto alcun backend.
+
+## Come usare
+
+1. Apri `index.html` in un browser moderno.
+2. Compila il form indicando il **Nome del Conto** e, facoltativamente, una serie di **tag** separati da virgola.
+3. Clicca su **Aggiungi Conto** per visualizzare il nuovo conto nella lista.
+4. Premi **Inserisci Transazione** per registrare un movimento su un conto. Oltre a conto, importo e tipo (entrata/uscita) viene richiesta anche la **categoria** dell'operazione e una descrizione facoltativa.
+5. Clicca su una card di conto per aprire una dashboard con la lista delle transazioni, le somme totali di entrate e uscite e il riepilogo per categoria.
+6. Ogni card mostra il saldo aggiornato e può essere eliminata tramite il pulsante *Elimina*.
+
+L'interfaccia è basata su [Bootstrap 5](https://getbootstrap.com/).
+
+## Categorie disponibili
+
+Le transazioni possono essere classificate scegliendo una di queste categorie:
+
+- 🍔 Cibo
+- 🛍️ Shopping
+- 🏠 Casa
+- 🚍 Trasporti
+- 🚗 Veicoli
+- 🎮 Intrattenimento
+- 💻 Comunicazione PC
+- 💳 Spese Finanziarie
+- 📈 Investimenti

--- a/README.md
+++ b/README.md
@@ -5,13 +5,16 @@ Questa semplice applicazione web permette di creare e gestire conti con un nome,
 ## Come usare
 
 1. Apri `index.html` in un browser moderno.
-2. Compila il form indicando il **Nome del Conto** e, facoltativamente, una serie di **tag** separati da virgola.
-3. Clicca su **Aggiungi Conto** per visualizzare il nuovo conto nella lista.
-4. Premi **Inserisci Transazione** per registrare un movimento su un conto. Oltre a conto, importo e tipo (entrata/uscita) viene richiesta anche la **categoria** dell'operazione e una descrizione facoltativa.
-5. Clicca su una card di conto per aprire una dashboard con la lista delle transazioni, le somme totali di entrate e uscite e il riepilogo per categoria.
-6. Ogni card mostra il saldo aggiornato e può essere eliminata tramite il pulsante *Elimina*.
+2. Usa la barra di navigazione per passare alle pagine **Dashboard**, **Statistiche** e **Transazioni**.
+3. In **Dashboard** trovi il riepilogo dei conti e le ultime operazioni.
+4. In **Statistiche** puoi visualizzare grafici dinamici scegliendo l'intervallo temporale (1 settimana, 1 mese, 6 mesi o 1 anno).
+5. Nella pagina **Transazioni** gestisci il registro completo e puoi aggiungere nuovi movimenti.
+6. Nell'homepage compila il form indicando il **Nome del Conto** e, facoltativamente, una serie di **tag** separati da virgola, quindi clicca **Aggiungi Conto**.
+7. Premi **Inserisci Transazione** per registrare un movimento su un conto. Oltre a conto, importo e tipo (entrata/uscita) viene richiesta anche la **categoria** dell'operazione e una descrizione facoltativa.
+8. Ogni card mostra il saldo aggiornato e può essere eliminata tramite il pulsante *Elimina*.
 
 L'interfaccia è basata su [Bootstrap 5](https://getbootstrap.com/).
+È disponibile una modalità **dark** attivabile tramite l'apposito interruttore nella navbar.
 
 ## Categorie disponibili
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="it" data-bs-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dashboard</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        body { padding-top: 80px; }
+    </style>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">Patrimonio</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link active" aria-current="page" href="dashboard.html">Dashboard</a></li>
+        <li class="nav-item"><a class="nav-link" href="statistiche.html">Statistiche</a></li>
+        <li class="nav-item"><a class="nav-link" href="transazioni.html">Transazioni</a></li>
+      </ul>
+      <div class="form-check form-switch">
+        <input class="form-check-input" type="checkbox" id="darkSwitch">
+        <label class="form-check-label" for="darkSwitch">Dark</label>
+      </div>
+    </div>
+  </div>
+</nav>
+<div class="container">
+  <h1 class="mb-4">Dashboard</h1>
+  <div class="row mb-4">
+    <div class="col-md-4">
+      <div class="card text-center">
+        <div class="card-body">
+          <h5 class="card-title">Numero Conti</h5>
+          <p id="accountsCount" class="display-6">0</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="card text-center">
+        <div class="card-body">
+          <h5 class="card-title">Saldo Totale</h5>
+          <p id="totalBalance" class="display-6">€0</p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <h2>Ultime Transazioni</h2>
+  <table class="table" id="lastTransactions">
+    <thead><tr><th>Data</th><th>Conto</th><th>Importo</th><th>Cat.</th></tr></thead>
+    <tbody></tbody>
+  </table>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+const darkSwitch = document.getElementById('darkSwitch');
+const accounts = JSON.parse(localStorage.getItem('accounts') || '[]');
+const transactions = JSON.parse(localStorage.getItem('transactions') || '[]');
+const categories = [
+    { name: 'Cibo', icon: '🍔' },
+    { name: 'Shopping', icon: '🛍️' },
+    { name: 'Casa', icon: '🏠' },
+    { name: 'Trasporti', icon: '🚍' },
+    { name: 'Veicoli', icon: '🚗' },
+    { name: 'Intrattenimento', icon: '🎮' },
+    { name: 'Comunicazione PC', icon: '💻' },
+    { name: 'Spese Finanziarie', icon: '💳' },
+    { name: 'Investimenti', icon: '📈' }
+];
+function getBalance(name){
+  return transactions.filter(t=>t.account===name)
+    .reduce((sum,t)=>sum+(t.type==='entrata'?t.amount:-t.amount),0);
+}
+function init(){
+  document.getElementById('accountsCount').textContent = accounts.length;
+  const total = accounts.reduce((s,a)=>s+getBalance(a.name),0);
+  document.getElementById('totalBalance').textContent = '€ '+total.toFixed(2);
+  const tbody = document.querySelector('#lastTransactions tbody');
+  const last = transactions.slice(-5).reverse();
+  tbody.innerHTML='';
+  last.forEach(t=>{
+    const tr=document.createElement('tr');
+    const cat = categories.find(c=>c.name===t.category);
+    const catLabel = cat?`${cat.icon} ${cat.name}`:t.category;
+    const sign = t.type==='entrata'?'+':'-';
+    tr.innerHTML=`<td>${new Date(t.date).toLocaleDateString()}</td><td>${t.account}</td><td>${sign}€ ${t.amount.toFixed(2)}</td><td>${catLabel}</td>`;
+    tbody.appendChild(tr);
+  });
+  const savedTheme = localStorage.getItem('theme')||'light';
+  document.documentElement.setAttribute('data-bs-theme', savedTheme);
+  darkSwitch.checked = savedTheme==='dark';
+}
+darkSwitch.addEventListener('change',()=>{
+  const theme = darkSwitch.checked ? 'dark' : 'light';
+  document.documentElement.setAttribute('data-bs-theme', theme);
+  localStorage.setItem('theme', theme);
+});
+init();
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="it">
+<html lang="it" data-bs-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,7 +7,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <style>
         body {
-            padding-top: 40px;
+            padding-top: 80px;
         }
         .account {
             margin-bottom: 1rem;
@@ -22,8 +22,27 @@
     </style>
 </head>
 <body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">Patrimonio</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link" href="dashboard.html">Dashboard</a></li>
+        <li class="nav-item"><a class="nav-link" href="statistiche.html">Statistiche</a></li>
+        <li class="nav-item"><a class="nav-link" href="transazioni.html">Transazioni</a></li>
+      </ul>
+      <div class="form-check form-switch">
+        <input class="form-check-input" type="checkbox" id="darkSwitch">
+        <label class="form-check-label" for="darkSwitch">Dark</label>
+      </div>
+    </div>
+  </div>
+</nav>
 <div class="container">
-    <h1 class="mb-4">Gestione del Patrimonio</h1>
+    <h1 class="mb-4 mt-4">Gestione del Patrimonio</h1>
     <div class="card mb-4">
         <div class="card-body">
             <form id="accountForm" class="row g-3">
@@ -277,6 +296,16 @@
     renderAccounts();
     populateAccountSelect();
     populateCategorySelect();
+
+    const savedTheme = localStorage.getItem('theme') || 'light';
+    document.documentElement.setAttribute('data-bs-theme', savedTheme);
+    darkSwitch.checked = savedTheme === 'dark';
+
+    darkSwitch.addEventListener('change', () => {
+        const theme = darkSwitch.checked ? 'dark' : 'light';
+        document.documentElement.setAttribute('data-bs-theme', theme);
+        localStorage.setItem('theme', theme);
+    });
 </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,282 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gestione Patrimonio</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        body {
+            padding-top: 40px;
+        }
+        .account {
+            margin-bottom: 1rem;
+        }
+        .tag {
+            display: inline-block;
+            background-color: #e2e3e5;
+            border-radius: 4px;
+            padding: 0.25rem 0.5rem;
+            margin-right: 0.25rem;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1 class="mb-4">Gestione del Patrimonio</h1>
+    <div class="card mb-4">
+        <div class="card-body">
+            <form id="accountForm" class="row g-3">
+                <div class="col-md-6">
+                    <label for="accountName" class="form-label">Nome Conto</label>
+                    <input type="text" class="form-control" id="accountName" required>
+                </div>
+                <div class="col-md-6">
+                    <label for="accountTags" class="form-label">Tag (separati da virgola)</label>
+                    <input type="text" class="form-control" id="accountTags">
+                </div>
+                <div class="col-12">
+                    <button type="submit" class="btn btn-primary">Aggiungi Conto</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <button class="btn btn-secondary mb-3" data-bs-toggle="modal" data-bs-target="#transactionModal">Inserisci Transazione</button>
+
+    <h2>Conti</h2>
+    <div id="accountsList"></div>
+
+<!-- Modal per nuova transazione -->
+<div class="modal fade" id="transactionModal" tabindex="-1" aria-labelledby="transactionModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form id="transactionForm">
+        <div class="modal-header">
+          <h5 class="modal-title" id="transactionModalLabel">Nuova Transazione</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label for="transactionAccount" class="form-label">Conto</label>
+            <select id="transactionAccount" class="form-select" required></select>
+          </div>
+          <div class="mb-3">
+            <label for="transactionAmount" class="form-label">Importo</label>
+            <input type="number" id="transactionAmount" class="form-control" required>
+          </div>
+          <div class="mb-3">
+            <label for="transactionType" class="form-label">Tipo</label>
+            <select id="transactionType" class="form-select">
+              <option value="entrata">Entrata</option>
+              <option value="uscita">Uscita</option>
+            </select>
+          </div>
+          <div class="mb-3">
+            <label for="transactionCategory" class="form-label">Categoria</label>
+            <select id="transactionCategory" class="form-select" required></select>
+          </div>
+          <div class="mb-3">
+            <label for="transactionDesc" class="form-label">Descrizione</label>
+            <input type="text" id="transactionDesc" class="form-control">
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annulla</button>
+          <button type="submit" class="btn btn-primary">Salva</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+</div>
+
+<!-- Modal dashboard conto -->
+<div class="modal fade" id="dashboardModal" tabindex="-1" aria-labelledby="dashboardModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="dashboardModalLabel">Dettagli Conto</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body" id="dashboardContent"></div>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+    const form = document.getElementById('accountForm');
+    const accountsList = document.getElementById('accountsList');
+    const transactionForm = document.getElementById('transactionForm');
+    const transactionAccount = document.getElementById('transactionAccount');
+    const transactionAmount = document.getElementById('transactionAmount');
+    const transactionType = document.getElementById('transactionType');
+    const transactionCategory = document.getElementById('transactionCategory');
+    const transactionDesc = document.getElementById('transactionDesc');
+
+    const categories = [
+        { name: 'Cibo', icon: '🍔' },
+        { name: 'Shopping', icon: '🛍️' },
+        { name: 'Casa', icon: '🏠' },
+        { name: 'Trasporti', icon: '🚍' },
+        { name: 'Veicoli', icon: '🚗' },
+        { name: 'Intrattenimento', icon: '🎮' },
+        { name: 'Comunicazione PC', icon: '💻' },
+        { name: 'Spese Finanziarie', icon: '💳' },
+        { name: 'Investimenti', icon: '📈' }
+    ];
+
+    let accounts = JSON.parse(localStorage.getItem('accounts') || '[]');
+    let transactions = JSON.parse(localStorage.getItem('transactions') || '[]');
+
+    function renderAccounts() {
+        accountsList.innerHTML = '';
+        accounts.forEach((account, index) => {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'account card';
+            wrapper.addEventListener('click', (e) => {
+                if (e.target.tagName === 'BUTTON') return;
+                renderDashboard(account.name);
+            });
+            const body = document.createElement('div');
+            body.className = 'card-body';
+
+            const title = document.createElement('h5');
+            title.className = 'card-title';
+            title.textContent = account.name;
+            body.appendChild(title);
+
+            if (account.tags.length) {
+                const tagsWrapper = document.createElement('div');
+                account.tags.forEach(tag => {
+                    const span = document.createElement('span');
+                    span.className = 'tag';
+                    span.textContent = tag.trim();
+                    tagsWrapper.appendChild(span);
+                });
+                body.appendChild(tagsWrapper);
+            }
+
+            const balance = getBalance(account.name);
+            const balanceEl = document.createElement('p');
+            balanceEl.className = 'mb-1';
+            balanceEl.innerHTML = `Saldo: <strong>€ ${balance.toFixed(2)}</strong>`;
+            body.appendChild(balanceEl);
+
+            const deleteButton = document.createElement('button');
+            deleteButton.className = 'btn btn-sm btn-danger mt-2';
+            deleteButton.textContent = 'Elimina';
+            deleteButton.addEventListener('click', () => {
+                accounts.splice(index, 1);
+                transactions = transactions.filter(t => t.account !== account.name);
+                saveAccounts();
+                saveTransactions();
+                renderAccounts();
+            });
+
+            body.appendChild(deleteButton);
+            wrapper.appendChild(body);
+            accountsList.appendChild(wrapper);
+        });
+    }
+
+    function saveAccounts() {
+        localStorage.setItem('accounts', JSON.stringify(accounts));
+    }
+
+    function saveTransactions() {
+        localStorage.setItem('transactions', JSON.stringify(transactions));
+    }
+
+    function getBalance(name) {
+        return transactions.filter(t => t.account === name)
+            .reduce((sum, t) => sum + (t.type === 'entrata' ? t.amount : -t.amount), 0);
+    }
+
+    function populateAccountSelect() {
+        transactionAccount.innerHTML = '';
+        accounts.forEach(acc => {
+            const option = document.createElement('option');
+            option.value = acc.name;
+            option.textContent = acc.name;
+            transactionAccount.appendChild(option);
+        });
+    }
+
+    function populateCategorySelect() {
+        transactionCategory.innerHTML = '';
+        categories.forEach(cat => {
+            const option = document.createElement('option');
+            option.value = cat.name;
+            option.textContent = `${cat.icon} ${cat.name}`;
+            transactionCategory.appendChild(option);
+        });
+    }
+
+    function renderDashboard(accountName) {
+        const modal = new bootstrap.Modal(document.getElementById('dashboardModal'));
+        const container = document.getElementById('dashboardContent');
+        const list = transactions.filter(t => t.account === accountName);
+        let entrate = 0, uscite = 0;
+        const byCat = {};
+        list.forEach(t => {
+            if (t.type === 'entrata') entrate += t.amount; else uscite += t.amount;
+            byCat[t.category] = (byCat[t.category] || 0) + (t.type === 'entrata' ? t.amount : -t.amount);
+        });
+        let html = `<h5 class="mb-3">${accountName}</h5>`;
+        html += '<p><strong>Entrate:</strong> € ' + entrate.toFixed(2) + ' | <strong>Uscite:</strong> € ' + uscite.toFixed(2) + '</p>';
+        html += '<table class="table"><thead><tr><th>Data</th><th>Importo</th><th>Cat.</th><th>Descrizione</th></tr></thead><tbody>';
+        list.forEach(t => {
+            const cat = categories.find(c => c.name === t.category);
+            const catLabel = cat ? `${cat.icon} ${cat.name}` : t.category;
+            const sign = t.type === 'entrata' ? '+' : '-';
+            html += `<tr><td>${new Date(t.date).toLocaleDateString()}</td><td>${sign}€ ${t.amount.toFixed(2)}</td><td>${catLabel}</td><td>${t.description || ''}</td></tr>`;
+        });
+        html += '</tbody></table>';
+        if (Object.keys(byCat).length) {
+            html += '<h6 class="mt-3">Totale per categoria</h6><ul>';
+            for (const [catName, val] of Object.entries(byCat)) {
+                const cat = categories.find(c => c.name === catName);
+                const label = cat ? `${cat.icon} ${cat.name}` : catName;
+                html += `<li>${label}: € ${val.toFixed(2)}</li>`;
+            }
+            html += '</ul>';
+        }
+        container.innerHTML = html;
+        modal.show();
+    }
+
+    form.addEventListener('submit', event => {
+        event.preventDefault();
+        const name = document.getElementById('accountName').value.trim();
+        const tags = document.getElementById('accountTags').value.split(',').map(tag => tag.trim()).filter(tag => tag);
+        if (!name) return;
+        accounts.push({ name, tags });
+        saveAccounts();
+        form.reset();
+        renderAccounts();
+        populateAccountSelect();
+    });
+
+    transactionForm.addEventListener('submit', event => {
+        event.preventDefault();
+        const account = transactionAccount.value;
+        const amount = parseFloat(transactionAmount.value);
+        if (!account || isNaN(amount)) return;
+        const type = transactionType.value;
+        const category = transactionCategory.value;
+        const description = transactionDesc.value.trim();
+        transactions.push({ account, amount, type, category, description, date: new Date().toISOString() });
+        saveTransactions();
+        transactionForm.reset();
+        bootstrap.Modal.getInstance(document.getElementById('transactionModal')).hide();
+        renderAccounts();
+    });
+
+    renderAccounts();
+    populateAccountSelect();
+    populateCategorySelect();
+</script>
+</body>
+</html>

--- a/statistiche.html
+++ b/statistiche.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="it" data-bs-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Statistiche</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+    <style>
+        body { padding-top: 80px; }
+    </style>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">Patrimonio</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link" href="dashboard.html">Dashboard</a></li>
+        <li class="nav-item"><a class="nav-link active" aria-current="page" href="statistiche.html">Statistiche</a></li>
+        <li class="nav-item"><a class="nav-link" href="transazioni.html">Transazioni</a></li>
+      </ul>
+      <div class="form-check form-switch">
+        <input class="form-check-input" type="checkbox" id="darkSwitch">
+        <label class="form-check-label" for="darkSwitch">Dark</label>
+      </div>
+    </div>
+  </div>
+</nav>
+<div class="container">
+  <h1 class="mb-4">Statistiche</h1>
+  <div class="mb-3">
+    <label for="rangeSelect" class="form-label">Intervallo</label>
+    <select id="rangeSelect" class="form-select w-auto d-inline-block">
+      <option value="7">1 settimana</option>
+      <option value="30">1 mese</option>
+      <option value="180">6 mesi</option>
+      <option value="365">1 anno</option>
+    </select>
+  </div>
+  <canvas id="statsChart" height="120"></canvas>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+const darkSwitch = document.getElementById('darkSwitch');
+const rangeSelect = document.getElementById('rangeSelect');
+const ctx = document.getElementById('statsChart');
+const transactions = JSON.parse(localStorage.getItem('transactions') || '[]');
+let chart;
+
+function prepareData(days){
+  const now = new Date();
+  const start = new Date(now.getTime()-days*24*60*60*1000);
+  const map = {};
+  transactions.forEach(t=>{
+    const d = new Date(t.date);
+    if(d<start || d>now) return;
+    const key = d.toISOString().slice(0,10);
+    if(!map[key]) map[key]={entrata:0, uscita:0};
+    map[key][t.type]+=t.amount;
+  });
+  const labels=Object.keys(map).sort();
+  const entrate=labels.map(l=>map[l].entrata);
+  const uscite=labels.map(l=>map[l].uscita);
+  return {labels,entrate,uscite};
+}
+
+function render(days){
+  const data=prepareData(days);
+  if(chart) chart.destroy();
+  chart=new Chart(ctx,{
+    type:'line',
+    data:{
+      labels:data.labels,
+      datasets:[
+        {label:'Entrate',data:data.entrate,borderColor:'green',tension:0.2},
+        {label:'Uscite',data:data.uscite,borderColor:'red',tension:0.2}
+      ]
+    },
+    options:{scales:{y:{beginAtZero:true}}}
+  });
+}
+
+rangeSelect.addEventListener('change',()=>render(parseInt(rangeSelect.value)));
+
+const savedTheme=localStorage.getItem('theme')||'light';
+document.documentElement.setAttribute('data-bs-theme',savedTheme);
+darkSwitch.checked=savedTheme==='dark';
+
+darkSwitch.addEventListener('change',()=>{
+  const theme=darkSwitch.checked?'dark':'light';
+  document.documentElement.setAttribute('data-bs-theme',theme);
+  localStorage.setItem('theme',theme);
+});
+
+render(parseInt(rangeSelect.value));
+</script>
+</body>
+</html>

--- a/transazioni.html
+++ b/transazioni.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="it" data-bs-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Transazioni</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>body{padding-top:80px;}</style>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="index.html">Patrimonio</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link" href="dashboard.html">Dashboard</a></li>
+        <li class="nav-item"><a class="nav-link" href="statistiche.html">Statistiche</a></li>
+        <li class="nav-item"><a class="nav-link active" aria-current="page" href="transazioni.html">Transazioni</a></li>
+      </ul>
+      <div class="form-check form-switch">
+        <input class="form-check-input" type="checkbox" id="darkSwitch">
+        <label class="form-check-label" for="darkSwitch">Dark</label>
+      </div>
+    </div>
+  </div>
+</nav>
+<div class="container">
+  <h1 class="mb-4">Transazioni</h1>
+  <button class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#transactionModal">Nuova Transazione</button>
+  <table class="table" id="transTable">
+    <thead><tr><th>Data</th><th>Conto</th><th>Importo</th><th>Cat.</th><th>Descrizione</th></tr></thead>
+    <tbody></tbody>
+  </table>
+</div>
+
+<!-- Modal per nuova transazione -->
+<div class="modal fade" id="transactionModal" tabindex="-1" aria-labelledby="transactionModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form id="transactionForm">
+        <div class="modal-header">
+          <h5 class="modal-title" id="transactionModalLabel">Nuova Transazione</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label for="transactionAccount" class="form-label">Conto</label>
+            <select id="transactionAccount" class="form-select" required></select>
+          </div>
+          <div class="mb-3">
+            <label for="transactionAmount" class="form-label">Importo</label>
+            <input type="number" id="transactionAmount" class="form-control" required>
+          </div>
+          <div class="mb-3">
+            <label for="transactionType" class="form-label">Tipo</label>
+            <select id="transactionType" class="form-select">
+              <option value="entrata">Entrata</option>
+              <option value="uscita">Uscita</option>
+            </select>
+          </div>
+          <div class="mb-3">
+            <label for="transactionCategory" class="form-label">Categoria</label>
+            <select id="transactionCategory" class="form-select" required></select>
+          </div>
+          <div class="mb-3">
+            <label for="transactionDesc" class="form-label">Descrizione</label>
+            <input type="text" id="transactionDesc" class="form-control">
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annulla</button>
+          <button type="submit" class="btn btn-primary">Salva</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+const darkSwitch=document.getElementById('darkSwitch');
+const transactionForm=document.getElementById('transactionForm');
+const transactionAccount=document.getElementById('transactionAccount');
+const transactionAmount=document.getElementById('transactionAmount');
+const transactionType=document.getElementById('transactionType');
+const transactionCategory=document.getElementById('transactionCategory');
+const transactionDesc=document.getElementById('transactionDesc');
+const tableBody=document.querySelector('#transTable tbody');
+let accounts=JSON.parse(localStorage.getItem('accounts')||'[]');
+let transactions=JSON.parse(localStorage.getItem('transactions')||'[]');
+const categories=[
+    {name:'Cibo',icon:'🍔'},
+    {name:'Shopping',icon:'🛍️'},
+    {name:'Casa',icon:'🏠'},
+    {name:'Trasporti',icon:'🚍'},
+    {name:'Veicoli',icon:'🚗'},
+    {name:'Intrattenimento',icon:'🎮'},
+    {name:'Comunicazione PC',icon:'💻'},
+    {name:'Spese Finanziarie',icon:'💳'},
+    {name:'Investimenti',icon:'📈'}
+];
+function populate(){
+  transactionAccount.innerHTML='';
+  accounts.forEach(a=>{
+    const opt=document.createElement('option');opt.value=a.name;opt.textContent=a.name;transactionAccount.appendChild(opt);});
+  transactionCategory.innerHTML='';
+  categories.forEach(c=>{const opt=document.createElement('option');opt.value=c.name;opt.textContent=`${c.icon} ${c.name}`;transactionCategory.appendChild(opt);});
+}
+function render(){
+  tableBody.innerHTML='';
+  transactions.forEach(t=>{
+    const tr=document.createElement('tr');
+    const cat=categories.find(c=>c.name===t.category);const catLabel=cat?`${cat.icon} ${cat.name}`:t.category;const sign=t.type==='entrata'?'+':'-';
+    tr.innerHTML=`<td>${new Date(t.date).toLocaleDateString()}</td><td>${t.account}</td><td>${sign}€ ${t.amount.toFixed(2)}</td><td>${catLabel}</td><td>${t.description||''}</td>`;
+    tableBody.appendChild(tr);
+  });
+}
+transactionForm.addEventListener('submit',e=>{
+  e.preventDefault();
+  const acc=transactionAccount.value;
+  const amount=parseFloat(transactionAmount.value);
+  if(!acc||isNaN(amount))return;
+  const type=transactionType.value;
+  const cat=transactionCategory.value;
+  const desc=transactionDesc.value.trim();
+  transactions.push({account:acc,amount,type,category:cat,description:desc,date:new Date().toISOString()});
+  localStorage.setItem('transactions',JSON.stringify(transactions));
+  transactionForm.reset();
+  bootstrap.Modal.getInstance(document.getElementById('transactionModal')).hide();
+  render();
+});
+const savedTheme=localStorage.getItem('theme')||'light';
+document.documentElement.setAttribute('data-bs-theme',savedTheme);
+darkSwitch.checked=savedTheme==='dark';
+darkSwitch.addEventListener('change',()=>{const theme=darkSwitch.checked?'dark':'light';document.documentElement.setAttribute('data-bs-theme',theme);localStorage.setItem('theme',theme);});
+populate();
+render();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add transaction category selection and icons
- show dashboard modal with history and stats when clicking an account
- document new usage and available categories in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684d89e6218c832c9d642d8c3fc3865b